### PR TITLE
Update plugins and dependencies for plugin validation issues (maven 3.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .settings
 .classpath
 .project
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -53,25 +53,26 @@
     <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
     <java.version>1.8</java.version>
     <jdk.version>1.8.0</jdk.version>
-    <junit.version>4.12</junit.version>
-    <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-javadoc-plugin.verison>3.0.0</maven-javadoc-plugin.verison>
-    <maven-plexus-component.version>1.7.1</maven-plexus-component.version>
-    <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
-    <maven-plugin.version>3.5.1</maven-plugin.version>
-    <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
-    <maven-source-plugin.verison>3.0.1</maven-source-plugin.verison>
-    <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
-    <maven-verifier.version>1.6</maven-verifier.version>
-    <maven.version>3.5.0</maven.version>
-    <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
+    <junit.version>4.13.2</junit.version>
+    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+    <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
+    <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
+    <maven-javadoc-plugin.verison>3.5.0</maven-javadoc-plugin.verison>
+    <maven-plexus-component.version>2.1.1</maven-plexus-component.version>
+    <maven-plugin-plugin.version>3.9.0</maven-plugin-plugin.version>
+    <maven-plugin.version>3.9.0</maven-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
+    <maven-site-plugin.verison>4.0.0-M8</maven-site-plugin.verison>
+    <maven-source-plugin.verison>3.3.0</maven-source-plugin.verison>
+    <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+    <maven-verifier.version>1.8.0</maven-verifier.version>
+    <maven.version>3.6.0</maven.version>
+    <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sortpom-maven-plugin.version>2.8.0</sortpom-maven-plugin.version>
-    <spotbugs-maven-plugin.version>3.1.3</spotbugs-maven-plugin.version>
-    <spotbugs.version>3.1.3</spotbugs.version>
-    <versions-maven-plugin.version>2.5</versions-maven-plugin.version>
+    <sortpom-maven-plugin.version>3.2.1</sortpom-maven-plugin.version>
+    <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
+    <spotbugs.version>4.7.3</spotbugs.version>
+    <versions-maven-plugin.version>2.16.0</versions-maven-plugin.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -79,16 +80,19 @@
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-core</artifactId>
         <version>${maven.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <version>${maven.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
         <version>${maven-plugin.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -178,6 +182,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>${maven-resources-plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>${maven-site-plugin.verison}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>ca.nanometrics.maven.plugins</groupId>
   <artifactId>maven-testtime-parent</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Tools to display how long tests took to run</description>

--- a/testtime-maven-extension/pom.xml
+++ b/testtime-maven-extension/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.nanometrics.maven.plugins</groupId>
     <artifactId>maven-testtime-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>testtime-maven-extension</artifactId>
   <name>ca.nanometrics.maven.plugins:testtime-maven-extension</name>

--- a/testtime-maven-plugin/pom.xml
+++ b/testtime-maven-plugin/pom.xml
@@ -17,16 +17,18 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>

--- a/testtime-maven-plugin/pom.xml
+++ b/testtime-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.nanometrics.maven.plugins</groupId>
     <artifactId>maven-testtime-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>testtime-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/testtime-tests/pom.xml
+++ b/testtime-tests/pom.xml
@@ -10,6 +10,14 @@
   <name>${project.groupId}:${project.artifactId}</name>
   <description>E2E tests for maven-testtime</description>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-verifier</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <testResources>
       <testResource>

--- a/testtime-tests/pom.xml
+++ b/testtime-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.nanometrics.maven.plugins</groupId>
     <artifactId>maven-testtime-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>testtime-tests</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>

--- a/testtime-tests/src/test/java/ca/nanometrics/maven/plugins/testtime/TestTimeTest.java
+++ b/testtime-tests/src/test/java/ca/nanometrics/maven/plugins/testtime/TestTimeTest.java
@@ -14,13 +14,13 @@ import org.apache.maven.it.Verifier;
 import org.apache.maven.it.util.ResourceExtractor;
 import org.junit.Test;
 
-public class TestTimeTest
-{
+public class TestTimeTest {
   @Test
-  public void testBasics() throws Exception
-  {
+  public void testBasics() throws Exception {
     File destination = new File("target/test-projects");
-    File projectDir = ResourceExtractor.extractResourcePath(getClass(), "/multi-module-project", destination, true);
+    File projectDir =
+        ResourceExtractor.extractResourcePath(
+            getClass(), "/multi-module-project", destination, true);
     System.out.println(projectDir.getAbsolutePath());
     assertThat(projectDir, is(notNullValue()));
     assertThat(projectDir.exists(), is(true));

--- a/testtime/pom.xml
+++ b/testtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.nanometrics.maven.plugins</groupId>
     <artifactId>maven-testtime-parent</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>testtime</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>

--- a/testtime/src/main/java/ca/nanometrics/maven/plugins/testtime/TestTimes.java
+++ b/testtime/src/main/java/ca/nanometrics/maven/plugins/testtime/TestTimes.java
@@ -19,6 +19,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * A helper class to keep track of test times during the maven lifecycle
+ */
 public class TestTimes
 {
   public static final String LOG_LIMIT_PROPERTY = "testtime.loglimit";
@@ -51,7 +54,7 @@ public class TestTimes
     m_directoriesToSearch = directoriesToSearch;
   }
 
-  public void processBuildDirectories(Path outputFolder, Collection<String> buildDirectories)
+  void processBuildDirectories(Path outputFolder, Collection<String> buildDirectories)
   {
     m_startTime = System.currentTimeMillis();
     List<Path> pathsToSearch = m_directoriesToSearch.stream().map(Paths::get).collect(Collectors.toList());


### PR DESCRIPTION
# Description

Update plugin for plugin validation rules being reported in Maven 3.9, in preparation for Maven 4.0.

 # Testing

* passes tests for me locally, including integration tests.
* using these changes now does not report plugin validation warnings.